### PR TITLE
include toggle mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ options = {
 };
 ```
 
+## What if I want to change the toggle steps on tapping / clicking the dial?
+
+Search the code and find `toggleValues` and set it to whatever list of values you want to toggle through. You can choose as many values as you like. Toggling will step through from left to right and back to start.
+```
+options = {
+       toggleValues: options.toggleValues || [10,22,30], // Values for toggling
+};
+```
+
 ## Issues:
 
 Use the GitHub issues log for raising issues or contributing suggestions and enhancements. [GITHUB](https://github.com/automatikas/Node-red-Nest-thermostat)


### PR DESCRIPTION
For quick switching, I added a toggle mode. When you tap/click on the widget, it toggles through a list of predefined values.

Toggling is assumed, when the delay of drag (500ms) is not reached. So the actual dragging behaviour is still functional in parallel.

I'm happy to discuss and adjust the approach, in case you don't like it.